### PR TITLE
feat(content): add values to the actual ship and defense cards

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3,16 +3,21 @@
   "workspaces": {
     "": {
       "name": "ogame-browser-extension",
+      "dependencies": {
+        "webextension-polyfill": "^0.12.0",
+      },
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
         "@commitlint/types": "^19.8.1",
         "@eslint/compat": "^1.2.9",
         "@eslint/js": "^9.27.0",
+        "@total-typescript/ts-reset": "^0.6.1",
         "@types/bun": "latest",
         "@types/chrome": "^0.0.323",
         "@types/fs-extra": "^11.0.4",
         "@types/node": "^22.15.21",
+        "@types/webextension-polyfill": "^0.12.3",
         "commitizen": "^4.3.1",
         "esbuild": "^0.25.4",
         "esbuild-plugin-copy": "^2.1.1",
@@ -189,6 +194,8 @@
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
+    "@total-typescript/ts-reset": ["@total-typescript/ts-reset@0.6.1", "", {}, "sha512-cka47fVSo6lfQDIATYqb/vO1nvFfbPw7uWLayIXIhGETj0wcOOlrlkobOMDNQOFr9QOafegUPq13V2+6vtD7yg=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.9.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw=="],
 
     "@types/bun": ["@types/bun@1.2.13", "", { "dependencies": { "bun-types": "1.2.13" } }, "sha512-u6vXep/i9VBxoJl3GjZsl/BFIsvML8DfVDO0RYLEwtSZSp981kEO1V5NwRcO1CPJ7AmvpbnDCiMKo3JvbDEjAg=="],
@@ -216,6 +223,8 @@
     "@types/minimatch": ["@types/minimatch@3.0.5", "", {}, "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="],
 
     "@types/node": ["@types/node@22.15.21", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ=="],
+
+    "@types/webextension-polyfill": ["@types/webextension-polyfill@0.12.3", "", {}, "sha512-F58aDVSeN/MjUGazXo/cPsmR76EvqQhQ1v4x23hFjUX0cfAJYE+JBWwiOGW36/VJGGxoH74sVlRIF3z7SJCKyg=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
@@ -1228,6 +1237,8 @@
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
 
     "web-ext": ["web-ext@8.6.0", "", { "dependencies": { "@babel/runtime": "7.27.0", "@devicefarmer/adbkit": "3.3.8", "addons-linter": "7.11.0", "camelcase": "8.0.0", "chrome-launcher": "1.1.2", "debounce": "1.2.1", "decamelize": "6.0.0", "es6-error": "4.1.1", "firefox-profile": "4.7.0", "fx-runner": "1.4.0", "https-proxy-agent": "^7.0.0", "jose": "5.9.6", "jszip": "3.10.1", "multimatch": "6.0.0", "node-notifier": "10.0.1", "open": "9.1.0", "parse-json": "7.1.1", "pino": "9.6.0", "promise-toolbox": "0.21.0", "source-map-support": "0.5.21", "strip-bom": "5.0.0", "strip-json-comments": "5.0.1", "tmp": "0.2.3", "update-notifier": "7.3.1", "watchpack": "2.4.2", "ws": "8.18.1", "yargs": "17.7.2", "zip-dir": "2.0.0" }, "bin": { "web-ext": "bin/web-ext.js" } }, "sha512-Y2b8YWtlrnJuAPzVAQJ7ewwmQcQGQp7Cdh8ijZTpv3dqMgR+pjMMjZExAgWVOwdYXIj96mTffHtFWlIS9Qd/pQ=="],
+
+    "webextension-polyfill": ["webextension-polyfill@0.12.0", "", {}, "sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q=="],
 
     "when": ["when@3.7.7", "", {}, "sha512-9lFZp/KHoqH6bPKjbWqa+3Dg/K/r2v0X/3/G2x4DBGchVS2QX2VXL3cZV994WQVnTM1/PD71Az25nAzryEUugw=="],
 

--- a/esbuild.config.ts
+++ b/esbuild.config.ts
@@ -20,6 +20,7 @@ export const buildOptions: BuildOptions = {
   platform: "browser",
   format: "iife",
   target: "es2020",
+  external: ["webextension-polyfill"],
   minify: process.env.NODE_ENV === "production",
   sourcemap: process.env.NODE_ENV !== "production",
   loader: {

--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
     "@commitlint/types": "^19.8.1",
     "@eslint/compat": "^1.2.9",
     "@eslint/js": "^9.27.0",
+    "@total-typescript/ts-reset": "^0.6.1",
     "@types/bun": "latest",
     "@types/chrome": "^0.0.323",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.15.21",
+    "@types/webextension-polyfill": "^0.12.3",
     "commitizen": "^4.3.1",
     "esbuild": "^0.25.4",
     "esbuild-plugin-copy": "^2.1.1",
@@ -48,5 +50,8 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.32.1",
     "web-ext": "^8.6.0"
+  },
+  "dependencies": {
+    "webextension-polyfill": "^0.12.0"
   }
 }

--- a/public/manifest.chrome.json
+++ b/public/manifest.chrome.json
@@ -21,7 +21,8 @@
   "content_scripts": [
     {
       "matches": ["*://*.ogame.gameforge.com/*"],
-      "js": ["content/content.js"]
+      "js": ["browser-polyfill.min.js", "content/content.js"],
+      "css": ["content/content.css"]
     }
   ],
   "icons": {

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -21,7 +21,8 @@
   "content_scripts": [
     {
       "matches": ["*://*.ogame.gameforge.com/*"],
-      "js": ["content/content.js"]
+      "js": ["browser-polyfill.min.js", "content/content.js"],
+      "css": ["content/content.css"]
     }
   ],
   "icons": {
@@ -30,7 +31,7 @@
   },
   "browser_specific_settings": {
     "gecko": {
-      "id": "ogame-extension@og-tools.xyz",
+      "id": "{722438ed-daec-40f4-80c4-b1ce0d093848}",
       "strict_min_version": "115.0"
     }
   }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -30,7 +30,7 @@
   },
   "browser_specific_settings": {
     "gecko": {
-      "id": "ogame-extension@og-tools.xyz",
+      "id": "{722438ed-daec-40f4-80c4-b1ce0d093848}",
       "strict_min_version": "115.0"
     }
   }

--- a/reset.d.ts
+++ b/reset.d.ts
@@ -1,0 +1,2 @@
+// Do not add any other lines of code to this file!
+import "@total-typescript/ts-reset";

--- a/src/content/content.css
+++ b/src/content/content.css
@@ -1,0 +1,19 @@
+.unit-container {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  background: linear-gradient(#0e1117, #1b222d);
+  padding: 2px 4px;
+  border-radius: 5px;
+  z-index: 100;
+}
+
+.unit-counter {
+  color: white;
+  font-size: 11px;
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5);
+}
+
+.technology {
+  position: relative;
+}

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -1,4 +1,72 @@
-// Apply red border to the page
-document.documentElement.style.border = "2px solid red";
+// Add content.css to the page
+const link = document.createElement("link");
+link.rel = "stylesheet";
+link.href = browser.runtime.getURL("content/content.css");
+document.head.appendChild(link);
+
+const getShipItems = (): Element[] => {
+  const container = document.getElementById("technologies_battle");
+  if (!container) return [];
+  const shipsItems = container.querySelectorAll(".technology[data-technology]");
+  return [...shipsItems];
+};
+
+const getDefenseItems = (): Element[] => {
+  const container = document.getElementById("defense");
+  if (!container) return [];
+  const rocketLauncherItem = container.querySelector(".rocketLauncher");
+  const laserCannonLightItem = container.querySelector(".laserCannonLight");
+  const laserCannonHeavyItem = container.querySelector(".laserCannonHeavy");
+  const gaussCannonItem = container.querySelector(".gaussCannon");
+  const ionCannonItem = container.querySelector(".ionCannon");
+  const plasmaCannonItem = container.querySelector(".plasmaCannon");
+  const items = [
+    rocketLauncherItem,
+    laserCannonLightItem,
+    laserCannonHeavyItem,
+    gaussCannonItem,
+    ionCannonItem,
+    plasmaCannonItem
+  ].filter(Boolean);
+  return items;
+};
+
+const getUnitItems = () => {
+  const shipItems = getShipItems();
+  const defenseItems = getDefenseItems();
+  const unitItems = [...shipItems, ...defenseItems];
+  return unitItems;
+};
+
+// Add counters to defense structures
+const updateUnitCounters = () => {
+  const unitItems = getUnitItems();
+  unitItems.forEach(item => {
+    const amountElement = item.querySelector(".stockAmount");
+    if (!amountElement) return;
+
+    // Remove existing counter if any
+    const existingCounter = item.querySelector(".unit-container");
+    if (existingCounter) {
+      existingCounter.remove();
+    }
+
+    const amount = amountElement.textContent ? amountElement.textContent.trim() : "0";
+    const counterContainer = document.createElement("div");
+    counterContainer.className = "unit-container";
+    const counter = document.createElement("span");
+    counter.className = "unit-counter";
+    counter.textContent = amount;
+    counterContainer.appendChild(counter);
+    item.appendChild(counterContainer);
+  });
+};
+
+// Initial update - wait for DOM to be ready
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", updateUnitCounters);
+} else {
+  updateUnitCounters();
+}
 
 export {};

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,6 @@
+import type { Browser } from "webextension-polyfill";
+
+declare global {
+  // The browser object is available globally from the polyfill
+  const browser: Browser;
+}

--- a/src/utils/build.utils.ts
+++ b/src/utils/build.utils.ts
@@ -1,0 +1,29 @@
+import { copy, ensureDir, readdir } from "fs-extra";
+import { join, dirname, relative } from "node:path";
+
+export const copyFiles = async (sourceDir: string, targetDir: string, ext: string) => {
+  if (!sourceDir || !targetDir || !ext) {
+    throw new Error("Invalid parameters: sourceDir, targetDir, and ext are required");
+  }
+
+  try {
+    const files = await readdir(sourceDir, { recursive: true, withFileTypes: true });
+
+    for (const file of files) {
+      if (!file.isFile() || !file.name.endsWith(ext)) continue;
+
+      // More compatible approach for getting parent path
+      const filePath = file.parentPath ?? sourceDir;
+      const relativePath = relative(sourceDir, filePath);
+      const srcPath = join(filePath, file.name);
+      const destPath = join(targetDir, relativePath, file.name);
+
+      await ensureDir(dirname(destPath));
+      await copy(srcPath, destPath, { overwrite: true });
+    }
+  } catch (error) {
+    let errorMessage = "Unknown error";
+    if (error instanceof Error) errorMessage = error.message;
+    throw new Error(`Failed to copy files: ${errorMessage}`);
+  }
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a browser polyfill and custom CSS for enhanced compatibility and styling in the extension.
  - Unit counters are now displayed as overlays on ship and defense items within supported pages.
- **Bug Fixes**
  - Improved manifest configurations for both Chrome and Firefox, ensuring correct script and style injection.
- **Chores**
  - Updated build process and dependencies to support polyfill integration and improved TypeScript type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->